### PR TITLE
feat: 재고 감소 이벤트 도메인 모델 완성 (출고/폐기)

### DIFF
--- a/src/main/java/com/forerp/erp/discard/domain/DiscardItem.java
+++ b/src/main/java/com/forerp/erp/discard/domain/DiscardItem.java
@@ -1,4 +1,4 @@
-package com.forerp.erp.discard;
+package com.forerp.erp.discard.domain;
 
 import com.forerp.erp.inventory.domain.InventoryHistory;
 import com.forerp.erp.inventory.domain.RefType;
@@ -31,6 +31,7 @@ public class DiscardItem {
     protected DiscardItem() {
     }
 
+    /* ===== 생성 로직 ===== */
     public static DiscardItem create(
             Discard discard,
             StoreProduct storeProduct,
@@ -45,6 +46,10 @@ public class DiscardItem {
         item.storeProduct = storeProduct;
         item.quantity = quantity;
         return item;
+    }
+
+    void assignDiscard(Discard discard) {
+        this.discard = discard;
     }
 
     /* ===== 폐기 실행 → 재고 감소 + 히스토리 생성 ===== */

--- a/src/main/java/com/forerp/erp/discard/domain/DiscardStatus.java
+++ b/src/main/java/com/forerp/erp/discard/domain/DiscardStatus.java
@@ -1,0 +1,6 @@
+package com.forerp.erp.discard.domain;
+
+public enum DiscardStatus {
+    CREATED,
+    CONFIRMED
+}

--- a/src/main/java/com/forerp/erp/discard/repository/DiscardRepository.java
+++ b/src/main/java/com/forerp/erp/discard/repository/DiscardRepository.java
@@ -1,0 +1,8 @@
+package com.forerp.erp.discard.repository;
+
+import com.forerp.erp.discard.domain.Discard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscardRepository extends JpaRepository<Discard, Long> {
+
+}

--- a/src/main/java/com/forerp/erp/discard/service/DiscardService.java
+++ b/src/main/java/com/forerp/erp/discard/service/DiscardService.java
@@ -1,0 +1,53 @@
+package com.forerp.erp.discard.service;
+
+import com.forerp.erp.discard.domain.Discard;
+import com.forerp.erp.discard.domain.DiscardItem;
+import com.forerp.erp.discard.domain.DiscardStatus;
+import com.forerp.erp.discard.repository.DiscardRepository;
+import com.forerp.erp.inventory.domain.InventoryHistory;
+import com.forerp.erp.inventory.repository.InventoryHistoryRepository;
+import com.forerp.erp.store.domain.Store;
+import com.forerp.erp.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DiscardService {
+
+    private final DiscardRepository discardRepository;
+    private final InventoryHistoryRepository inventoryHistoryRepository;
+
+    /* ===== 폐기 생성 ===== */
+    public Discard createDiscard(
+            Store store,
+            String reason,
+            User actor,
+            List<DiscardItem> items
+    ) {
+        Discard discard = Discard.create(store, reason, actor, items);
+        return discardRepository.save(discard);
+    }
+
+    /* ===== 폐기 확정 ===== */
+    public void confirmDiscard(Long discardId, User actor) {
+        Discard discard = discardRepository.findById(discardId)
+                .orElseThrow(() -> new IllegalArgumentException("폐기 내역을 찾을 수 없습니다."));
+
+        if (discard.getStatus() == DiscardStatus.CONFIRMED) {
+            throw new IllegalStateException("이미 확정된 폐기입니다.");
+        }
+
+        // 재고 차감 + 히스토리 생성
+        discard.getItems().forEach(item -> {
+            InventoryHistory history = item.discard(actor);
+            inventoryHistoryRepository.save(history);
+        });
+
+        discard.confirm();
+    }
+}

--- a/src/main/java/com/forerp/erp/inventory/domain/InventoryHistory.java
+++ b/src/main/java/com/forerp/erp/inventory/domain/InventoryHistory.java
@@ -76,7 +76,7 @@ public class InventoryHistory {
         this.actorUser = actorUser;
     }
 
-    /* ===== 출고/입고/조정 공통 ===== */
+    /* ===== 생성 로직 (감소/증가 공통) ===== */
     public static InventoryHistory create(
             StoreProduct storeProduct,
             ChangeType changeType,

--- a/src/main/java/com/forerp/erp/inventory/repository/InventoryHistoryRepository.java
+++ b/src/main/java/com/forerp/erp/inventory/repository/InventoryHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.forerp.erp.inventory.repository;
+
+import com.forerp.erp.inventory.domain.InventoryHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InventoryHistoryRepository extends JpaRepository<InventoryHistory, Long> {
+
+}

--- a/src/main/java/com/forerp/erp/outbound/domain/Outbound.java
+++ b/src/main/java/com/forerp/erp/outbound/domain/Outbound.java
@@ -22,11 +22,11 @@ public class Outbound {
     @Column(name = "outbound_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
@@ -36,12 +36,17 @@ public class Outbound {
     @OneToMany(mappedBy = "outbound", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OutboundItem> items = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OutboundStatus status;
+
     /* ===== 생성 로직 ===== */
     public static Outbound create(Order order, Store store, List<OutboundItem> items) {
         Outbound outbound = new Outbound();
         outbound.order = order;
         outbound.store = store;
         outbound.createdAt = LocalDateTime.now();
+        outbound.status = OutboundStatus.CREATED;
 
         items.forEach(item -> {
             item.assignOutbound(outbound);
@@ -49,5 +54,13 @@ public class Outbound {
         });
 
         return outbound;
+    }
+
+    /* ===== 확정 로직 ===== */
+    public void confirm() {
+        if (this.status == OutboundStatus.CONFIRMED) {
+            throw new IllegalStateException("이미 확정된 출고입니다.");
+        }
+        this.status = OutboundStatus.CONFIRMED;
     }
 }

--- a/src/main/java/com/forerp/erp/outbound/domain/OutboundItem.java
+++ b/src/main/java/com/forerp/erp/outbound/domain/OutboundItem.java
@@ -1,6 +1,10 @@
 package com.forerp.erp.outbound.domain;
 
+import com.forerp.erp.inventory.domain.InventoryHistory;
+import com.forerp.erp.inventory.domain.RefType;
 import com.forerp.erp.order.domain.OrderItem;
+import com.forerp.erp.product.domain.StoreProduct;
+import com.forerp.erp.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,26 +21,50 @@ public class OutboundItem {
     @Column(name = "outbound_item_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "outbound_id", nullable = false)
     private Outbound outbound;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "order_item_id", nullable = false)
     private OrderItem orderItem;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_product_id", nullable = false)
+    private StoreProduct storeProduct;
 
     @Column(nullable = false)
     private int quantity;
 
     /* ===== 생성 로직 ===== */
-    public static OutboundItem create(OrderItem orderItem, int quantity) {
+    public static OutboundItem create(
+            OrderItem orderItem,
+            StoreProduct storeProduct,
+            int quantity
+    ) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("출고 수량은 0보다 커야 합니다.");
+        }
+
         OutboundItem item = new OutboundItem();
         item.orderItem = orderItem;
+        item.storeProduct = storeProduct;
         item.quantity = quantity;
         return item;
     }
 
     void assignOutbound(Outbound outbound) {
         this.outbound = outbound;
+    }
+
+    /* ===== 출고 실행 → 재고 감소 + 히스토리 생성 ===== */
+    public InventoryHistory ship(User actor) {
+        return storeProduct.decreaseStock(
+                quantity,
+                RefType.OUTBOUND,
+                outbound.getId(),
+                this.id,
+                actor
+        );
     }
 }

--- a/src/main/java/com/forerp/erp/outbound/domain/OutboundStatus.java
+++ b/src/main/java/com/forerp/erp/outbound/domain/OutboundStatus.java
@@ -1,0 +1,6 @@
+package com.forerp.erp.outbound.domain;
+
+public enum OutboundStatus {
+    CREATED,
+    CONFIRMED
+}

--- a/src/main/java/com/forerp/erp/outbound/repository/OutboundRepository.java
+++ b/src/main/java/com/forerp/erp/outbound/repository/OutboundRepository.java
@@ -1,0 +1,8 @@
+package com.forerp.erp.outbound.repository;
+
+import com.forerp.erp.outbound.domain.Outbound;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboundRepository extends JpaRepository<Outbound, Long> {
+
+}

--- a/src/main/java/com/forerp/erp/outbound/service/OutboundService.java
+++ b/src/main/java/com/forerp/erp/outbound/service/OutboundService.java
@@ -1,0 +1,53 @@
+package com.forerp.erp.outbound.service;
+
+import com.forerp.erp.inventory.domain.InventoryHistory;
+import com.forerp.erp.inventory.repository.InventoryHistoryRepository;
+import com.forerp.erp.order.domain.Order;
+import com.forerp.erp.outbound.domain.Outbound;
+import com.forerp.erp.outbound.domain.OutboundItem;
+import com.forerp.erp.outbound.domain.OutboundStatus;
+import com.forerp.erp.outbound.repository.OutboundRepository;
+import com.forerp.erp.store.domain.Store;
+import com.forerp.erp.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OutboundService {
+
+    private final OutboundRepository outboundRepository;
+    private final InventoryHistoryRepository inventoryHistoryRepository;
+
+    /* ===== 출고 생성 ===== */
+    public Outbound createOutbound(
+            Order order,
+            Store store,
+            List<OutboundItem> items
+    ) {
+        Outbound outbound = Outbound.create(order, store, items);
+        return outboundRepository.save(outbound);
+    }
+
+    /* ===== 출고 확정 ===== */
+    public void confirmOutbound(Long outboundId, User actor) {
+        Outbound outbound = outboundRepository.findById(outboundId)
+                .orElseThrow(() -> new IllegalArgumentException("출고를 찾을 수 없습니다."));
+
+        if (outbound.getStatus() == OutboundStatus.CONFIRMED) {
+            throw new IllegalStateException("이미 확정된 출고입니다.");
+        }
+
+        // 재고 차감 + 히스토리 생성
+        outbound.getItems().forEach(item -> {
+            InventoryHistory history = item.ship(actor);
+            inventoryHistoryRepository.save(history);
+        });
+
+        outbound.confirm(); // status 변경
+    }
+}

--- a/src/main/java/com/forerp/erp/product/domain/StoreProduct.java
+++ b/src/main/java/com/forerp/erp/product/domain/StoreProduct.java
@@ -90,6 +90,7 @@ public class StoreProduct {
 
         int before = this.quantity;
         this.quantity -= qty;
+        this.isSellable = calculateSellable();
         int after = this.quantity;
 
         return InventoryHistory.create(
@@ -105,7 +106,7 @@ public class StoreProduct {
         );
     }
 
-    /* ===== 재고 증가 (반품/입고) ===== */
+    /* ===== 재고 증가 ===== */
     public InventoryHistory increaseStock(
             int qty,
             RefType refType,
@@ -119,6 +120,7 @@ public class StoreProduct {
 
         int before = this.quantity;
         this.quantity += qty;
+        this.isSellable = calculateSellable();
         int after = this.quantity;
 
         return InventoryHistory.create(


### PR DESCRIPTION
## 작업 내용
- 재고 감소 이벤트 (출고/폐기) 로직 확정
- 출고/폐기 생성 및 확정 상태 분기
- 확정 시 재고 감소 로직(decreaseStock) 사용
- 로그 생성

## 변경 이유
- 재고 감소 이벤트에 따른 재고 흐름 및 로그 동기화

## 영향 범위
- 물류 쪽

## 테스트
- 로컬 테스트 완료