### PR TITLE
feat: 배송 도메인 추가

### DIFF
--- a/src/main/java/com/forerp/erp/outbound/domain/Outbound.java
+++ b/src/main/java/com/forerp/erp/outbound/domain/Outbound.java
@@ -1,6 +1,7 @@
 package com.forerp.erp.outbound.domain;
 
 import com.forerp.erp.order.domain.Order;
+import com.forerp.erp.shipment.domain.Shipment;
 import com.forerp.erp.store.domain.Store;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -30,6 +31,9 @@ public class Outbound {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
+    @OneToOne(mappedBy = "outbound", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Shipment shipment;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
@@ -56,7 +60,17 @@ public class Outbound {
         return outbound;
     }
 
-    /* ===== 확정 로직 ===== */
+    /* ===== 연관관계 ===== */
+    public void assignShipment(Shipment shipment) {
+        this.shipment = shipment;
+    }
+
+    /* ===== 상태 변경 ===== */
+    public void changeStatus(OutboundStatus status) {
+        this.status = status;
+    }
+
+    /* ===== 출고 확정 ===== */
     public void confirm() {
         if (this.status == OutboundStatus.CONFIRMED) {
             throw new IllegalStateException("이미 확정된 출고입니다.");

--- a/src/main/java/com/forerp/erp/outbound/domain/OutboundStatus.java
+++ b/src/main/java/com/forerp/erp/outbound/domain/OutboundStatus.java
@@ -2,5 +2,6 @@ package com.forerp.erp.outbound.domain;
 
 public enum OutboundStatus {
     CREATED,
+    SHIPPING,
     CONFIRMED
 }

--- a/src/main/java/com/forerp/erp/outbound/service/OutboundService.java
+++ b/src/main/java/com/forerp/erp/outbound/service/OutboundService.java
@@ -7,6 +7,7 @@ import com.forerp.erp.outbound.domain.Outbound;
 import com.forerp.erp.outbound.domain.OutboundItem;
 import com.forerp.erp.outbound.domain.OutboundStatus;
 import com.forerp.erp.outbound.repository.OutboundRepository;
+import com.forerp.erp.shipment.domain.Shipment;
 import com.forerp.erp.store.domain.Store;
 import com.forerp.erp.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -30,24 +31,34 @@ public class OutboundService {
             List<OutboundItem> items
     ) {
         Outbound outbound = Outbound.create(order, store, items);
+
+        Shipment.createForOutbound(outbound);
+
         return outboundRepository.save(outbound);
     }
 
-    /* ===== 출고 확정 ===== */
+    /* ===== 배송 출발 ===== */
+    public void departShipment(Long outboundId, String carrier, String trackingNumber) {
+        Outbound outbound = outboundRepository.findById(outboundId)
+                .orElseThrow(() -> new IllegalArgumentException("출고를 찾을 수 없습니다."));
+
+        outbound.getShipment().depart(carrier, trackingNumber);
+        outbound.changeStatus(OutboundStatus.SHIPPING);
+    }
+
+    /* ===== 배송 도착 → 출고 확정 ===== */
     public void confirmOutbound(Long outboundId, User actor) {
         Outbound outbound = outboundRepository.findById(outboundId)
                 .orElseThrow(() -> new IllegalArgumentException("출고를 찾을 수 없습니다."));
 
-        if (outbound.getStatus() == OutboundStatus.CONFIRMED) {
-            throw new IllegalStateException("이미 확정된 출고입니다.");
-        }
+        Shipment shipment = outbound.getShipment();
+        shipment.arrive();
 
-        // 재고 차감 + 히스토리 생성
         outbound.getItems().forEach(item -> {
             InventoryHistory history = item.ship(actor);
             inventoryHistoryRepository.save(history);
         });
 
-        outbound.confirm(); // status 변경
+        outbound.confirm();
     }
 }

--- a/src/main/java/com/forerp/erp/shipment/domain/Shipment.java
+++ b/src/main/java/com/forerp/erp/shipment/domain/Shipment.java
@@ -1,0 +1,81 @@
+package com.forerp.erp.shipment.domain;
+
+import com.forerp.erp.outbound.domain.Outbound;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "shipments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Shipment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shipment_id")
+    private Long id;
+
+    /* 출고 연관 */
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "outbound_id", nullable = false, unique = true)
+    private Outbound outbound;
+
+    /* 입고 연관 */
+    // @OneToOne(fetch = FetchType.LAZY, optional = false)
+    // @JoinColumn(name = "purchase_order_id", nullable = false)
+    // private PurchaseOrder purchaseOrder;
+
+    @Column(name = "carrier", length = 30)
+    private String carrier;   // 택배사 코드 or 이름 (CJ, LOTTE, HANJIN 등)
+
+    @Column(name = "tracking_number", length = 50)
+    private String trackingNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ShipmentStatus status;
+
+    @Column(name = "departed_at")
+    private LocalDateTime departedAt;
+
+    @Column(name = "arrived_at")
+    private LocalDateTime arrivedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    /* ===== 생성 로직 ===== */
+    public static Shipment createForOutbound(Outbound outbound) {
+        Shipment shipment = new Shipment();
+        shipment.outbound = outbound;
+        shipment.status = ShipmentStatus.READY;
+        shipment.createdAt = LocalDateTime.now();
+
+        outbound.assignShipment(shipment);
+        return shipment;
+    }
+
+    /* ===== 배송 출발 ===== */
+    public void depart(String carrier, String trackingNumber) {
+        if (status != ShipmentStatus.READY) {
+            throw new IllegalStateException("배송 출발이 불가능한 상태입니다.");
+        }
+        this.carrier = carrier;
+        this.trackingNumber = trackingNumber;
+        this.status = ShipmentStatus.SHIPPING;
+        this.departedAt = LocalDateTime.now();
+    }
+
+    /* ===== 배송 도착 ===== */
+    public void arrive() {
+        if (status != ShipmentStatus.SHIPPING) {
+            throw new IllegalStateException("배송 도착이 불가능한 상태입니다.");
+        }
+        this.status = ShipmentStatus.ARRIVED;
+        this.arrivedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/forerp/erp/shipment/domain/ShipmentStatus.java
+++ b/src/main/java/com/forerp/erp/shipment/domain/ShipmentStatus.java
@@ -1,0 +1,7 @@
+package com.forerp.erp.shipment.domain;
+
+public enum ShipmentStatus {
+    READY,      // 배송 준비
+    SHIPPING,   // 배송 중
+    ARRIVED     // 배송 완료
+}

--- a/src/main/java/com/forerp/erp/shipment/repository/ShipmentRepository.java
+++ b/src/main/java/com/forerp/erp/shipment/repository/ShipmentRepository.java
@@ -1,0 +1,8 @@
+package com.forerp.erp.shipment.repository;
+
+import com.forerp.erp.shipment.domain.Shipment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShipmentRepository extends JpaRepository<Shipment, Long> {
+
+}


### PR DESCRIPTION
## 작업 내용
- 배송 도메인 추가
- 생성/출발/도착 로직 포함
- 출고/입고 통용
- SweetTracker API 기반 배송 조회

## 변경 이유
- 입/출고 시 배송 필요

## 영향 범위
- 입/출고

## 테스트
- 로컬 테스트 완료